### PR TITLE
feat: Add `withDefaults` snippet for `defineProps`

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ These snippets were made to speed up Vue 3 development. With it you can write bo
 | `vonunmounted`             | onUnmounted hook            |
 | `vonbeforeunmount`         | onBeforeUnmount hook        |
 | `vdefineprops`             | Define props                |
-| `vdefinepropswithdefaults` | Define props with defaults  |
+| `vdefineprops-withdefaults` | Define props with defaults  |
 | `vdefineemits`             | Define emits                |
 | `vsingleemit`              | Single emit for defineEmits |
 | `vdefineslots`             | Define slots                |

--- a/README.md
+++ b/README.md
@@ -63,27 +63,28 @@ These snippets were made to speed up Vue 3 development. With it you can write bo
 
 ### Script
 
-| Snippet            | Purpose                     |
-| ------------------ | --------------------------- |
-| `vref`             | Vue `ref`                   |
-| `vreactive`        | Vue `reactive`              |
-| `vcomputed`        | Vue `computed`              |
-| `vwatch`           | Watcher                     |
-| `vwatcheffect`     | Watch Effect                |
-| `vonmounted`       | onMounted hook              |
-| `vonbeforemount`   | onBeforeMount hook          |
-| `vonbeforeupdate`  | onBeforeUpdate hook         |
-| `vonupdated`       | onUpdated hook              |
-| `vonerrorcaptured` | onErrorCaptured hook        |
-| `vonunmounted`     | onUnmounted hook            |
-| `vonbeforeunmount` | onBeforeUnmount hook        |
-| `vdefineprops`     | Define props                |
-| `vdefineemits`     | Define emits                |
-| `vsingleemit`      | Single emit for defineEmits |
-| `vdefineslots`     | Define slots                |
-| `vsingleslot`      | Single slot for defineSlots |
-| `vdefineoptions`   | Define Options              |
-| `vdefinemodel`     | Define Model                |
+| Snippet                    | Purpose                     |
+| -------------------------- | --------------------------- |
+| `vref`                     | Vue `ref`                   |
+| `vreactive`                | Vue `reactive`              |
+| `vcomputed`                | Vue `computed`              |
+| `vwatch`                   | Watcher                     |
+| `vwatcheffect`             | Watch Effect                |
+| `vonmounted`               | onMounted hook              |
+| `vonbeforemount`           | onBeforeMount hook          |
+| `vonbeforeupdate`          | onBeforeUpdate hook         |
+| `vonupdated`               | onUpdated hook              |
+| `vonerrorcaptured`         | onErrorCaptured hook        |
+| `vonunmounted`             | onUnmounted hook            |
+| `vonbeforeunmount`         | onBeforeUnmount hook        |
+| `vdefineprops`             | Define props                |
+| `vdefinepropswithdefaults` | Define props with defaults  |
+| `vdefineemits`             | Define emits                |
+| `vsingleemit`              | Single emit for defineEmits |
+| `vdefineslots`             | Define slots                |
+| `vsingleslot`              | Single slot for defineSlots |
+| `vdefineoptions`           | Define Options              |
+| `vdefinemodel`             | Define Model                |
 
 ### CSS
 

--- a/snippets/vue/vue-script.code-snippets
+++ b/snippets/vue/vue-script.code-snippets
@@ -107,6 +107,17 @@
     ],
     "description": "Vue defineProps"
   },
+  "Vue Define Props with defaults": {
+    "prefix": "vdefinepropswithdefaults",
+    "body": [
+      "withDefaults(defineProps<{",
+      "\t${1:name}: ${2:type}",
+      "}>(), {",
+      "\t${1:name}: ${3:default}",
+      "})"
+    ],
+    "description": "Vue withDefaults(defineProps)"
+  },
   "Vue Define Emits": {
     "prefix": "vdefineemits",
     "body": [

--- a/snippets/vue/vue-script.code-snippets
+++ b/snippets/vue/vue-script.code-snippets
@@ -108,7 +108,7 @@
     "description": "Vue defineProps"
   },
   "Vue Define Props with defaults": {
-    "prefix": "vdefinepropswithdefaults",
+    "prefix": "vdefineprops-withdefaults",
     "body": [
       "withDefaults(defineProps<{",
       "\t${1:name}: ${2:type}",


### PR DESCRIPTION
Add snippet for `withDefaults` compiler macro, see [Default props values when using type declaration](https://vuejs.org/api/sfc-script-setup.html#default-props-values-when-using-type-declaration)