### PR TITLE
feat: Add `ref` with generic type argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,27 +63,28 @@ These snippets were made to speed up Vue 3 development. With it you can write bo
 
 ### Script
 
-| Snippet            | Purpose                     |
-| ------------------ | --------------------------- |
-| `vref`             | Vue `ref`                   |
-| `vreactive`        | Vue `reactive`              |
-| `vcomputed`        | Vue `computed`              |
-| `vwatch`           | Watcher                     |
-| `vwatcheffect`     | Watch Effect                |
-| `vonmounted`       | onMounted hook              |
-| `vonbeforemount`   | onBeforeMount hook          |
-| `vonbeforeupdate`  | onBeforeUpdate hook         |
-| `vonupdated`       | onUpdated hook              |
-| `vonerrorcaptured` | onErrorCaptured hook        |
-| `vonunmounted`     | onUnmounted hook            |
-| `vonbeforeunmount` | onBeforeUnmount hook        |
-| `vdefineprops`     | Define props                |
-| `vdefineemits`     | Define emits                |
-| `vsingleemit`      | Single emit for defineEmits |
-| `vdefineslots`     | Define slots                |
-| `vsingleslot`      | Single slot for defineSlots |
-| `vdefineoptions`   | Define Options              |
-| `vdefinemodel`     | Define Model                |
+| Snippet                    | Purpose                     |
+| -------------------------- | --------------------------- |
+| `vref`                     | Vue `ref`                   |
+| `vreactive`                | Vue `reactive`              |
+| `vcomputed`                | Vue `computed`              |
+| `vwatch`                   | Watcher                     |
+| `vwatcheffect`             | Watch Effect                |
+| `vonmounted`               | onMounted hook              |
+| `vonbeforemount`           | onBeforeMount hook          |
+| `vonbeforeupdate`          | onBeforeUpdate hook         |
+| `vonupdated`               | onUpdated hook              |
+| `vonerrorcaptured`         | onErrorCaptured hook        |
+| `vonunmounted`             | onUnmounted hook            |
+| `vonbeforeunmount`         | onBeforeUnmount hook        |
+| `vdefineprops`             | Define props                |
+| `vdefineprops-withdefaults` | Define props with defaults  |
+| `vdefineemits`             | Define emits                |
+| `vsingleemit`              | Single emit for defineEmits |
+| `vdefineslots`             | Define slots                |
+| `vsingleslot`              | Single slot for defineSlots |
+| `vdefineoptions`           | Define Options              |
+| `vdefinemodel`             | Define Model                |
 
 ### CSS
 

--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ These snippets were made to speed up Vue 3 development. With it you can write bo
 | Snippet                    | Purpose                     |
 | -------------------------- | --------------------------- |
 | `vref`                     | Vue `ref`                   |
+| `vref-typed`               | Vue `ref` with generic type argument |
 | `vreactive`                | Vue `reactive`              |
 | `vcomputed`                | Vue `computed`              |
 | `vwatch`                   | Watcher                     |

--- a/snippets/vue/vue-script.code-snippets
+++ b/snippets/vue/vue-script.code-snippets
@@ -4,6 +4,11 @@
     "body": ["const ${1:name} = ref(${2:initialValue})"],
     "description": "Vue Ref"
   },
+  "Vue Ref typed": {
+    "prefix": "vref-typed",
+    "body": ["const ${1:name} = ref<${2:type}>(${3:initialValue})"],
+    "description": "Vue Ref with generic type argument"
+  },
   "Vue Reactive": {
     "prefix": "vreactive",
     "body": ["const ${1:name} = reactive({", "\t${2:count}: ${3:0}", "})"],

--- a/snippets/vue/vue-script.code-snippets
+++ b/snippets/vue/vue-script.code-snippets
@@ -107,6 +107,17 @@
     ],
     "description": "Vue defineProps"
   },
+  "Vue Define Props with defaults": {
+    "prefix": "vdefineprops-withdefaults",
+    "body": [
+      "withDefaults(defineProps<{",
+      "\t${1:name}: ${2:type}",
+      "}>(), {",
+      "\t${1:name}: ${3:default}",
+      "})"
+    ],
+    "description": "Vue withDefaults(defineProps)"
+  },
   "Vue Define Emits": {
     "prefix": "vdefineemits",
     "body": [


### PR DESCRIPTION
Add snippet for `ref` with generic type argument, see [Typing ref()](https://vuejs.org/guide/typescript/composition-api.html#typing-ref)