### PR TITLE
feat(pinia)!: Use Composition API in the default `pstore` snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,10 +125,10 @@ Example — `<script setup>` without TypeScript, template first, plain unscoped 
 
 ### Pinia
 
-| Snippet              | Purpose                                                      |
-| -------------------- | ------------------------------------------------------------ |
-| `pstore`             | Base code needed for a Pinia store file                      |
-| `pstore-composition` | Base code needed for a Pinia store file with Composition API |
+| Snippet          | Purpose                                                  |
+| ---------------- | -------------------------------------------------------- |
+| `pstore`         | Base code needed for a Pinia store file                  |
+| `pstore-options` | Base code needed for a Pinia store file with Options API |
 
 ### Vue Router
 

--- a/snippets/pinia/pinia.code-snippets
+++ b/snippets/pinia/pinia.code-snippets
@@ -4,6 +4,22 @@
     "body": [
       "import { defineStore, acceptHMRUpdate } from \"pinia\"",
       "",
+      "export const use${TM_FILENAME_BASE/(.*)/${1:/capitalize}/}Store = defineStore(\"$TM_FILENAME_BASE\", () => {",
+      "\t${0}",
+      "})",
+      "",
+      "if (import.meta.hot) {",
+      "\timport.meta.hot.accept(acceptHMRUpdate(use${TM_FILENAME_BASE/(.*)/${1:/capitalize}/}Store, import.meta.hot))",
+      "}",
+      ""
+    ],
+    "description": "Base code needed for a Pinia store file"
+  },
+  "Pinia Store Base - Options API": {
+    "prefix": "pstore-options",
+    "body": [
+      "import { defineStore, acceptHMRUpdate } from \"pinia\"",
+      "",
       "export const use${TM_FILENAME_BASE/(.*)/${1:/capitalize}/}Store = defineStore(\"$TM_FILENAME_BASE\", {",
       "\tstate: () => ({",
       "\t\t$0",
@@ -17,22 +33,6 @@
       "}",
       ""
     ],
-    "description": "Base code needed for a Pinia store file"
-  },
-  "Pinia Store Base - Composition API": {
-    "prefix": "pstore-composition",
-    "body": [
-      "import { defineStore, acceptHMRUpdate } from \"pinia\"",
-      "",
-      "export const use${TM_FILENAME_BASE/(.*)/${1:/capitalize}/}Store = defineStore(\"$TM_FILENAME_BASE\", () => {",
-      "\t${0}",
-      "})",
-      "",
-      "if (import.meta.hot) {",
-      "\timport.meta.hot.accept(acceptHMRUpdate(use${TM_FILENAME_BASE/(.*)/${1:/capitalize}/}Store, import.meta.hot))",
-      "}",
-      ""
-    ],
-    "description": "Base code needed for a Pinia store file with Composition API"
+    "description": "Base code needed for a Pinia store file with Options API"
   }
 }


### PR DESCRIPTION
Part of #81.

- `pstore` now generates a Composition API (setup) store
- The Options API variant moved from `pstore-composition` to `pstore-options`

**Breaking change:** the `pstore-composition` prefix no longer exists, and `pstore` produces different output.