### PR TITLE
feat(pinia): Configurable `pstore` snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ These snippets were made to speed up Vue 3 development. With it you can write bo
 
 ## Configuration
 
+### `vbase`
+
 The `vbase` snippet can be fully configured in your `settings.json`, so you can make it produce exactly the base file you want without reaching for the other `vbase-*` snippets. Without any configuration it produces a Vue SFC with `<script setup lang="ts">`, a `<template>` with a `div` root tag and a scoped `SCSS` `<style>` block.
 
 | Setting                             | Default                           | Description                                                                                                                      |
@@ -52,19 +54,34 @@ Example — `<script setup>` without TypeScript, template first, plain unscoped 
 }
 ```
 
+### `pstore`
+
+The `pstore` snippet is configurable too. Without any configuration it produces a Composition API Pinia store with an `acceptHMRUpdate` block.
+
+| Setting                  | Default         | Description                                                                                 |
+| ------------------------ | --------------- | ------------------------------------------------------------------------------------------- |
+| `vueSnippets.pstore.api` | `"composition"` | API style: `composition` (setup function) or `options` (`state`/`getters`/`actions` object) |
+| `vueSnippets.pstore.hmr` | `true`          | Add the `acceptHMRUpdate` block                                                             |
+
+Example — an Options API store without HMR:
+
+```json
+{ "vueSnippets.pstore.api": "options", "vueSnippets.pstore.hmr": false }
+```
+
 ## Snippets
 
 ### `.vue` files
 
-| Snippet      | Purpose                                                                                                    |
-| ------------ | ---------------------------------------------------------------------------------------------------------- |
-| `vbase`      | Base for Vue 3 File. [Configurable](#configuration), defaults to `<script setup>`, `TypeScript` and `SCSS` |
-| `vbase-sass` | Base for Vue 3 File with `<script setup>`, `TypeScript` and `SASS`                                         |
-| `vbase-less` | Base for Vue 3 File with `<script setup>`, `TypeScript` and `LESS`                                         |
-| `vbase-pcss` | Base for Vue 3 File with `<script setup>`, `TypeScript` and `PostCSS`                                      |
-| `vbase-css`  | Base for Vue 3 File with `<script setup>`, `TypeScript` and `CSS`                                          |
-| `vbase-styl` | Base for Vue 3 File with `<script setup>`, `TypeScript` and `Stylus`                                       |
-| `vbase-ns`   | Base for Vue 3 File with `<script setup>`, `TypeScript` and no style                                       |
+| Snippet      | Purpose                                                                                            |
+| ------------ | -------------------------------------------------------------------------------------------------- |
+| `vbase`      | Base for Vue 3 File. [Configurable](#vbase), defaults to `<script setup>`, `TypeScript` and `SCSS` |
+| `vbase-sass` | Base for Vue 3 File with `<script setup>`, `TypeScript` and `SASS`                                 |
+| `vbase-less` | Base for Vue 3 File with `<script setup>`, `TypeScript` and `LESS`                                 |
+| `vbase-pcss` | Base for Vue 3 File with `<script setup>`, `TypeScript` and `PostCSS`                              |
+| `vbase-css`  | Base for Vue 3 File with `<script setup>`, `TypeScript` and `CSS`                                  |
+| `vbase-styl` | Base for Vue 3 File with `<script setup>`, `TypeScript` and `Stylus`                               |
+| `vbase-ns`   | Base for Vue 3 File with `<script setup>`, `TypeScript` and no style                               |
 
 ### Template
 
@@ -125,10 +142,10 @@ Example — `<script setup>` without TypeScript, template first, plain unscoped 
 
 ### Pinia
 
-| Snippet          | Purpose                                                  |
-| ---------------- | -------------------------------------------------------- |
-| `pstore`         | Base code needed for a Pinia store file                  |
-| `pstore-options` | Base code needed for a Pinia store file with Options API |
+| Snippet          | Purpose                                                                                                |
+| ---------------- | ------------------------------------------------------------------------------------------------------ |
+| `pstore`         | Base code needed for a Pinia store file. [Configurable](#pstore), defaults to Composition API with HMR |
+| `pstore-options` | Base code needed for a Pinia store file with Options API                                               |
 
 ### Vue Router
 

--- a/package.json
+++ b/package.json
@@ -63,6 +63,20 @@
     "configuration": {
       "title": "Vue 3 VS Code Snippets",
       "properties": {
+        "vueSnippets.pstore.api": {
+          "type": "string",
+          "enum": [
+            "composition",
+            "options"
+          ],
+          "default": "composition",
+          "markdownDescription": "API style of the `pstore` snippet: a setup function (`composition`) or a `state`/`getters`/`actions` object (`options`)."
+        },
+        "vueSnippets.pstore.hmr": {
+          "type": "boolean",
+          "default": true,
+          "markdownDescription": "Add the `acceptHMRUpdate` block to the `pstore` snippet."
+        },
         "vueSnippets.vbase.scriptLang": {
           "type": "string",
           "enum": [
@@ -221,6 +235,8 @@
     ]
   },
   "activationEvents": [
+    "onLanguage:javascript",
+    "onLanguage:typescript",
     "onLanguage:vue"
   ],
   "nano-staged": {

--- a/snippets/pinia/pinia.code-snippets
+++ b/snippets/pinia/pinia.code-snippets
@@ -1,20 +1,4 @@
 {
-  "Pinia Store Base": {
-    "prefix": "pstore",
-    "body": [
-      "import { defineStore, acceptHMRUpdate } from \"pinia\"",
-      "",
-      "export const use${TM_FILENAME_BASE/(.*)/${1:/capitalize}/}Store = defineStore(\"$TM_FILENAME_BASE\", () => {",
-      "\t${0}",
-      "})",
-      "",
-      "if (import.meta.hot) {",
-      "\timport.meta.hot.accept(acceptHMRUpdate(use${TM_FILENAME_BASE/(.*)/${1:/capitalize}/}Store, import.meta.hot))",
-      "}",
-      ""
-    ],
-    "description": "Base code needed for a Pinia store file"
-  },
   "Pinia Store Base - Options API": {
     "prefix": "pstore-options",
     "body": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,9 +3,10 @@ import type * as vscode from "vscode"
 import type { ConfigurableSnippet } from "./types"
 
 import { registerConfigurableSnippet } from "./register"
+import { pstore } from "./snippets/pstore"
 import { vbase } from "./snippets/vbase"
 
-const SNIPPETS: ConfigurableSnippet[] = [vbase]
+const SNIPPETS: ConfigurableSnippet[] = [pstore, vbase]
 
 /**
  * Registers every configurable snippet completion.

--- a/src/snippets/pstore.ts
+++ b/src/snippets/pstore.ts
@@ -1,0 +1,85 @@
+import * as vscode from "vscode"
+
+import type { ConfigurableSnippet, PiniaApi, PstoreConfig } from "../types"
+
+/** Snippet transform turning the file name into a capitalized store name. */
+const STORE_NAME = "${TM_FILENAME_BASE/(.*)/${1:/capitalize}/}"
+
+/** Configurable `pstore` snippet: a base Pinia store. */
+export const pstore: ConfigurableSnippet = {
+  buildBody: () => buildPstoreBody(readPstoreConfig()),
+  detail: "Base code needed for a Pinia store file",
+  languages: ["javascript", "typescript"],
+  prefix: "pstore",
+  section: "vueSnippets.pstore",
+}
+
+/**
+ * Builds the `acceptHMRUpdate` block of the `pstore` snippet.
+ *
+ * @returns The `import.meta.hot` block snippet text.
+ */
+function buildHmrBlock(): string {
+  return [
+    "if (import.meta.hot) {",
+    `\timport.meta.hot.accept(acceptHMRUpdate(use${STORE_NAME}Store, import.meta.hot))`,
+    "}",
+  ].join("\n")
+}
+
+/**
+ * Builds the full body of the `pstore` snippet.
+ *
+ * @param config Resolved `pstore` configuration.
+ * @returns The snippet body for the configured API with or without HMR.
+ */
+function buildPstoreBody(config: PstoreConfig): string {
+  const imports = config.hmr ? "defineStore, acceptHMRUpdate" : "defineStore"
+
+  const blocks = [
+    `import { ${imports} } from "pinia"`,
+    buildStoreBlock(config),
+    config.hmr ? buildHmrBlock() : undefined,
+  ].filter((block) => block !== undefined)
+
+  return blocks.join("\n\n")
+}
+
+/**
+ * Builds the `defineStore` block of the `pstore` snippet.
+ *
+ * @param config Resolved `pstore` configuration.
+ * @returns The `defineStore` block snippet text.
+ */
+function buildStoreBlock(config: PstoreConfig): string {
+  const declaration = `export const use${STORE_NAME}Store = defineStore("$TM_FILENAME_BASE", `
+
+  if (config.api === "composition") {
+    return `${declaration}() => {\n\t\${0}\n})`
+  }
+
+  return [
+    `${declaration}{`,
+    "\tstate: () => ({",
+    "\t\t${0}",
+    "\t}),",
+    "\tgetters: {},",
+    "\tactions: {},",
+    "})",
+  ].join("\n")
+}
+
+/**
+ * Reads the `vueSnippets.pstore` configuration, falling back to the defaults
+ * for the `pstore` snippet.
+ *
+ * @returns Resolved `pstore` configuration.
+ */
+function readPstoreConfig(): PstoreConfig {
+  const config = vscode.workspace.getConfiguration("vueSnippets.pstore")
+
+  return {
+    api: config.get<PiniaApi>("api", "composition"),
+    hmr: config.get<boolean>("hmr", true),
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,6 +13,13 @@ export interface ConfigurableSnippet {
   section: string
 }
 
+export type PiniaApi = "composition" | "options"
+
+export interface PstoreConfig {
+  api: PiniaApi
+  hmr: boolean
+}
+
 export type ScriptLang = "js" | "ts"
 
 export type StyleLang =

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -8,7 +8,7 @@ describe("activate", () => {
     languages.registerCompletionItemProvider.mockClear()
   })
 
-  test("registers the vbase completion for vue files", () => {
+  test("registers every configurable snippet for its languages", () => {
     activate({ subscriptions: [] } as never)
 
     const languagesRegistered =
@@ -17,5 +17,7 @@ describe("activate", () => {
       )
 
     expect(languagesRegistered).toContain("vue")
+    expect(languagesRegistered).toContain("javascript")
+    expect(languagesRegistered).toContain("typescript")
   })
 })

--- a/tests/snippets/pstore.spec.ts
+++ b/tests/snippets/pstore.spec.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, test } from "vitest"
+
+import { pstore } from "../../src/snippets/pstore"
+import { setSettings } from "../mocks/vscode"
+
+const STORE_NAME = "${TM_FILENAME_BASE/(.*)/${1:/capitalize}/}"
+
+describe("pstore snippet", () => {
+  beforeEach(() => {
+    setSettings({})
+  })
+
+  test("targets the script languages with the pstore prefix", () => {
+    expect(pstore.prefix).toBe("pstore")
+    expect(pstore.languages).toStrictEqual(["javascript", "typescript"])
+  })
+
+  test("produces a Composition API store with HMR by default", () => {
+    expect(pstore.buildBody()).toBe(
+      [
+        'import { defineStore, acceptHMRUpdate } from "pinia"',
+        "",
+        `export const use${STORE_NAME}Store = defineStore("$TM_FILENAME_BASE", () => {`,
+        "\t${0}",
+        "})",
+        "",
+        "if (import.meta.hot) {",
+        `\timport.meta.hot.accept(acceptHMRUpdate(use${STORE_NAME}Store, import.meta.hot))`,
+        "}",
+      ].join("\n"),
+    )
+  })
+
+  test("produces an Options API store when the api is options", () => {
+    setSettings({ api: "options" })
+
+    expect(pstore.buildBody()).toBe(
+      [
+        'import { defineStore, acceptHMRUpdate } from "pinia"',
+        "",
+        `export const use${STORE_NAME}Store = defineStore("$TM_FILENAME_BASE", {`,
+        "\tstate: () => ({",
+        "\t\t${0}",
+        "\t}),",
+        "\tgetters: {},",
+        "\tactions: {},",
+        "})",
+        "",
+        "if (import.meta.hot) {",
+        `\timport.meta.hot.accept(acceptHMRUpdate(use${STORE_NAME}Store, import.meta.hot))`,
+        "}",
+      ].join("\n"),
+    )
+  })
+
+  test("omits the HMR block and its import when hmr is disabled", () => {
+    setSettings({ hmr: false })
+
+    expect(pstore.buildBody()).toBe(
+      [
+        'import { defineStore } from "pinia"',
+        "",
+        `export const use${STORE_NAME}Store = defineStore("$TM_FILENAME_BASE", () => {`,
+        "\t${0}",
+        "})",
+      ].join("\n"),
+    )
+  })
+
+  test("combines all settings", () => {
+    setSettings({ api: "options", hmr: false })
+
+    expect(pstore.buildBody()).toBe(
+      [
+        'import { defineStore } from "pinia"',
+        "",
+        `export const use${STORE_NAME}Store = defineStore("$TM_FILENAME_BASE", {`,
+        "\tstate: () => ({",
+        "\t\t${0}",
+        "\t}),",
+        "\tgetters: {},",
+        "\tactions: {},",
+        "})",
+      ].join("\n"),
+    )
+  })
+})


### PR DESCRIPTION
Closes #81.

- `pstore` is now driven by a `CompletionItemProvider` that builds its body from the `vueSnippets.pstore.*` settings: `api` (`composition` by default, or `options`) and `hmr` (`true` by default). Disabling `hmr` drops both the `import.meta.hot` block and the `acceptHMRUpdate` import.
- The static `pstore` entry is removed from `snippets/pinia/pinia.code-snippets`; `pstore-options` stays as a variant, mirroring `vbase` and its `vbase-*` siblings.
- `onLanguage:javascript` and `onLanguage:typescript` are added to `activationEvents` — the extension only activated on `.vue`, so the new completion would never fire in a store file.