### PR TITLE
feat(vue): Vapor mode support in `vbase` snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The `vbase` snippet can be fully configured in your `settings.json`, so you can 
 | ----------------------------------- | --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | `vueSnippets.vbase.scriptLang`      | `"ts"`                            | Language of the `<script>` block: `ts` or `js` (`js` omits the `lang` attribute)                                                 |
 | `vueSnippets.vbase.scriptSetup`     | `true`                            | Use `<script setup>`                                                                                                             |
+| `vueSnippets.vbase.scriptVapor`     | `false`                           | Use `<script vapor>`, the shorthand for `<script setup vapor>` (takes precedence over `scriptSetup`)                             |
 | `vueSnippets.vbase.styleLang`       | `"scss"`                          | Language of the `<style>` block: `scss`, `sass`, `less`, `postcss`, `css`, `stylus` or `none` (`none` omits the `<style>` block) |
 | `vueSnippets.vbase.styleScoped`     | `true`                            | Add the `scoped` attribute to the `<style>` block                                                                                |
 | `vueSnippets.vbase.templateRootTag` | `"div"`                           | Root tag wrapping the cursor inside `<template>` (empty string omits the wrapper)                                                |
@@ -73,15 +74,16 @@ Example — an Options API store without HMR:
 
 ### `.vue` files
 
-| Snippet      | Purpose                                                                                            |
-| ------------ | -------------------------------------------------------------------------------------------------- |
-| `vbase`      | Base for Vue 3 File. [Configurable](#vbase), defaults to `<script setup>`, `TypeScript` and `SCSS` |
-| `vbase-sass` | Base for Vue 3 File with `<script setup>`, `TypeScript` and `SASS`                                 |
-| `vbase-less` | Base for Vue 3 File with `<script setup>`, `TypeScript` and `LESS`                                 |
-| `vbase-pcss` | Base for Vue 3 File with `<script setup>`, `TypeScript` and `PostCSS`                              |
-| `vbase-css`  | Base for Vue 3 File with `<script setup>`, `TypeScript` and `CSS`                                  |
-| `vbase-styl` | Base for Vue 3 File with `<script setup>`, `TypeScript` and `Stylus`                               |
-| `vbase-ns`   | Base for Vue 3 File with `<script setup>`, `TypeScript` and no style                               |
+| Snippet       | Purpose                                                                                            |
+| ------------- | -------------------------------------------------------------------------------------------------- |
+| `vbase`       | Base for Vue 3 File. [Configurable](#vbase), defaults to `<script setup>`, `TypeScript` and `SCSS` |
+| `vbase-sass`  | Base for Vue 3 File with `<script setup>`, `TypeScript` and `SASS`                                 |
+| `vbase-less`  | Base for Vue 3 File with `<script setup>`, `TypeScript` and `LESS`                                 |
+| `vbase-pcss`  | Base for Vue 3 File with `<script setup>`, `TypeScript` and `PostCSS`                              |
+| `vbase-css`   | Base for Vue 3 File with `<script setup>`, `TypeScript` and `CSS`                                  |
+| `vbase-styl`  | Base for Vue 3 File with `<script setup>`, `TypeScript` and `Stylus`                               |
+| `vbase-ns`    | Base for Vue 3 File with `<script setup>`, `TypeScript` and no style                               |
+| `vbase-vapor` | Base for Vue 3 File with `<script vapor>`, `TypeScript` and `SCSS`                                 |
 
 ### Template
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,11 @@
           "default": true,
           "markdownDescription": "Use `<script setup>` in the `vbase` snippet."
         },
+        "vueSnippets.vbase.scriptVapor": {
+          "type": "boolean",
+          "default": false,
+          "markdownDescription": "Use `<script vapor>` in the `vbase` snippet. Vapor mode implies `setup`, so this shorthand is used regardless of `#vueSnippets.vbase.scriptSetup#`."
+        },
         "vueSnippets.vbase.styleLang": {
           "type": "string",
           "enum": [

--- a/snippets/vue/vue.code-snippets
+++ b/snippets/vue/vue.code-snippets
@@ -109,4 +109,23 @@
     ],
     "description": "Base for Vue 3 File with <script setup>, TypeScript and no style",
   },
+  "Vue SFC <script vapor>, TS, SCSS": {
+    "prefix": "vbase-vapor",
+    "body": [
+      "<script vapor lang=\"ts\">",
+      "",
+      "</script>",
+      "",
+      "<template>",
+      "\t<div>",
+      "\t\t${0}",
+      "\t</div>",
+      "</template>",
+      "",
+      "<style lang=\"scss\" scoped>",
+      "",
+      "</style>",
+    ],
+    "description": "Base for Vue 3 File with <script vapor>, TypeScript and SCSS",
+  },
 }

--- a/src/snippets/vbase.ts
+++ b/src/snippets/vbase.ts
@@ -22,14 +22,21 @@ export const vbase: ConfigurableSnippet = {
 /**
  * Builds the `<script>` block of the `vbase` snippet.
  *
+ * Vapor mode implies `setup`, so `<script vapor>` is always emitted as the
+ * shorthand for `<script setup vapor>`.
+ *
  * @param config Resolved `vbase` configuration.
  * @returns The `<script>` block snippet text.
  */
 function buildScriptBlock(config: VbaseConfig): string {
-  const setup = config.scriptSetup ? " setup" : ""
   const lang = config.scriptLang === "ts" ? ' lang="ts"' : ""
 
-  return `<script${setup}${lang}>\n\n</script>`
+  let mode = ""
+
+  if (config.scriptVapor) mode = " vapor"
+  else if (config.scriptSetup) mode = " setup"
+
+  return `<script${mode}${lang}>\n\n</script>`
 }
 
 /**
@@ -107,6 +114,7 @@ function readVbaseConfig(): VbaseConfig {
     blockOrder,
     scriptLang: config.get<ScriptLang>("scriptLang", "ts"),
     scriptSetup: config.get<boolean>("scriptSetup", true),
+    scriptVapor: config.get<boolean>("scriptVapor", false),
     styleLang: config.get<StyleLang>("styleLang", "scss"),
     styleScoped: config.get<boolean>("styleScoped", true),
     templateRootTag: config.get<string>("templateRootTag", "div"),

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,6 +35,7 @@ export interface VbaseConfig {
   blockOrder: Block[]
   scriptLang: ScriptLang
   scriptSetup: boolean
+  scriptVapor: boolean
   styleLang: StyleLang
   styleScoped: boolean
   templateRootTag: string

--- a/tests/snippets/vbase.spec.ts
+++ b/tests/snippets/vbase.spec.ts
@@ -45,6 +45,15 @@ describe("vbase snippet", () => {
     expect(vbase.buildBody()).toContain('<script lang="ts">')
   })
 
+  test.each([true, false])(
+    "uses the vapor shorthand when scriptVapor is enabled and scriptSetup is %s",
+    (scriptSetup) => {
+      setSettings({ scriptSetup, scriptVapor: true })
+
+      expect(vbase.buildBody()).toContain('<script vapor lang="ts">')
+    },
+  )
+
   test.each(["sass", "less", "postcss", "css", "stylus"] as const)(
     "uses %s as the style language",
     (lang) => {
@@ -135,6 +144,7 @@ describe("vbase snippet", () => {
       blockOrder: ["template", "script", "style"],
       scriptLang: "js",
       scriptSetup: true,
+      scriptVapor: true,
       styleLang: "css",
       styleScoped: false,
       templateRootTag: "",
@@ -146,7 +156,7 @@ describe("vbase snippet", () => {
         "\t${0}",
         "</template>",
         "",
-        "<script setup>",
+        "<script vapor>",
         "",
         "</script>",
         "",


### PR DESCRIPTION
Closes #72

- Add the `vueSnippets.vbase.scriptVapor` setting that switches the `<script>` block of the configurable `vbase` snippet to `<script vapor>`. Vapor mode implies `setup`, so this shorthand is used regardless of `scriptSetup`.
- Add the static `vbase-vapor` snippet: `<script vapor lang="ts">`, `TypeScript` and scoped `SCSS`.
- Document both in `README.md`.